### PR TITLE
multi-account dashboard

### DIFF
--- a/app/core/components/__init__.py
+++ b/app/core/components/__init__.py
@@ -19,6 +19,7 @@ from .display.processing_now import ProcessingNow
 # Input components
 from .input.welcome import Welcome
 from .input.account_dashboard import AccountDashboard
+from .input.multi_account_dashboard import MultiAccountDashboard
 from .input.offer_list_display import OfferListDisplay
 from .input.view_ledger import ViewLedger
 from .input.amount_input import AmountInput
@@ -53,6 +54,7 @@ __all__ = [
 
     # Input components
     "AccountDashboard",
+    "MultiAccountDashboard",
     "OfferListDisplay",
     "ViewLedger",
     "Welcome",

--- a/app/core/components/api/login_api_call.py
+++ b/app/core/components/api/login_api_call.py
@@ -65,9 +65,18 @@ class LoginApiCall(ApiComponent):
                 self.set_result("start_onboarding")
                 return ValidationResult.success(None)
 
-            # For existing members, set active account
+            # For existing members, check tier and handle routing
             try:
                 dashboard = self.state_manager.get_state_value("dashboard", {})
+                member = dashboard.get("member", {})
+                member_tier = member.get("memberTier")
+
+                # For tier 5, show multi-account dashboard
+                if member_tier == 5:
+                    self.set_result("send_multi_dashboard")
+                    return ValidationResult.success(result)
+
+                # For other tiers, set personal account as active
                 accounts = dashboard.get("accounts", [])
                 personal_account = next(
                     (acc for acc in accounts if acc.get("accountType") == "PERSONAL"),

--- a/app/core/components/input/account_dashboard.py
+++ b/app/core/components/input/account_dashboard.py
@@ -161,10 +161,12 @@ class AccountDashboard(InputComponent):
                         rows=account_options
                     ))
 
-                # Member Actions section - only show if there are member actions
+                # Member Actions section
                 member_options = []
                 if member.get("memberTier") == 1:
                     member_options.append({"id": "upgrade_membertier", "title": "🌟 Hustler Tier 💫", "description": "$1/month *First 10,000 Hustlers: $1 for the first year* 🔥💥💥"})
+                elif member.get("memberTier") == 5:
+                    member_options.append({"id": "switch_account", "title": "🔄 Switch Account", "description": "Switch to a different account"})
 
                 if member_options:
                     sections.append(Section(
@@ -210,7 +212,8 @@ class AccountDashboard(InputComponent):
                             "decline_offer",
                             "cancel_offer",
                             "view_ledger",
-                            "upgrade_membertier"
+                            "upgrade_membertier",
+                            "switch_account"
                         ]
                         if selection in valid_paths:
                             # Tell headquarters which path to take and release input wait

--- a/app/core/components/input/multi_account_dashboard.py
+++ b/app/core/components/input/multi_account_dashboard.py
@@ -1,0 +1,170 @@
+"""Multi-account dashboard component
+
+This component handles displaying the multi-account dashboard for memberTier=5 users.
+Allows selection of accounts to transition into specific account flows.
+"""
+
+import logging
+from typing import Any
+
+from core.components.base import InputComponent
+from core.error.types import ValidationResult
+from core.messaging.types import InteractiveType, MessageType, Section
+
+logger = logging.getLogger(__name__)
+
+# Multi-account template
+MULTI_ACCOUNT_DASHBOARD = """*👋 Hie {firstname}*"""
+
+
+class MultiAccountDashboard(InputComponent):
+    """Handles multi-account dashboard display and account selection"""
+
+    def __init__(self):
+        super().__init__("multi_account_dashboard")
+
+    def validate_display(self, value: Any) -> ValidationResult:
+        """Validate display and handle account selection"""
+        # Validate state manager is set
+        if not self.state_manager:
+            return ValidationResult.failure(
+                message="State manager not set",
+                field="state_manager",
+                details={"component": "multi_account_dashboard"}
+            )
+
+        try:
+            # Display Phase - When not awaiting input
+            if not self.state_manager.is_awaiting_input():
+                # Get and validate dashboard data
+                dashboard = self.state_manager.get_state_value("dashboard")
+                if not dashboard:
+                    return ValidationResult.failure(
+                        message="No dashboard data found",
+                        field="dashboard",
+                        details={"component": "multi_account_dashboard"}
+                    )
+
+                # Get member info
+                member = dashboard.get("member", {})
+                firstname = member.get("firstname", "")
+
+                # Get accounts
+                accounts = dashboard.get("accounts", [])
+                if not accounts:
+                    return ValidationResult.failure(
+                        message="No accounts found",
+                        field="accounts",
+                        details={"component": "multi_account_dashboard"}
+                    )
+
+                # Format header with member name
+                header = MULTI_ACCOUNT_DASHBOARD.format(firstname=firstname)
+
+                # Create account selection options
+                account_options = []
+                for account in accounts:
+                    if account.get("isOwnedAccount"):
+                        account_id = account.get("accountID")
+                        account_name = account.get("accountName", "")
+                        account_handle = account.get("accountHandle", "")
+
+                        # WhatsApp's 24 char limit for title
+                        # "💳 " takes 4 chars, leaving 20 chars
+                        max_name_length = 20
+                        truncated_handle = (
+                            account_handle[:max_name_length]
+                            if len(account_handle) > max_name_length
+                            else account_handle
+                        )
+
+                        # Get net assets in default denomination
+                        net_assets = account.get("balanceData", {}).get("netCredexAssetsInDefaultDenom", "0.00")
+
+                        try:
+                            # Build concise description (under 72 chars)
+                            description = f"{account_name}: {net_assets}"
+                        except Exception as e:
+                            logger.error(f"Failed to build description: {str(e)}")
+                            # Provide a fallback description
+                            description = f"Type: {account.get('accountType')}"
+
+                        account_options.append({
+                            "id": account_id,
+                            "title": f"💳 {truncated_handle}",
+                            "description": description
+                        })
+
+                if not account_options:
+                    return ValidationResult.failure(
+                        message="No owned accounts found",
+                        field="accounts",
+                        details={"component": "multi_account_dashboard"}
+                    )
+
+                # Create sections for menu
+                sections = [
+                    Section(
+                        title="Your Accounts",
+                        rows=account_options
+                    )
+                ]
+
+                try:
+                    # Set component to await input before sending menu
+                    self.set_awaiting_input(True)
+
+                    # Send interactive menu
+                    self.state_manager.messaging.send_interactive(
+                        body=header,
+                        sections=sections,
+                        button_text="Select Account 💳"
+                    )
+
+                    return ValidationResult.success(True)
+                except Exception as e:
+                    return ValidationResult.failure(
+                        message=f"Failed to send menu message: {str(e)}",
+                        field="display",
+                        details={
+                            "component": "multi_account_dashboard",
+                            "error": str(e),
+                            "type": "validation"
+                        }
+                    )
+
+            # Input Phase - When we get a response
+            component_data = self.state_manager.get_state_value("component_data", {})
+            incoming_message = component_data.get("incoming_message", {})
+
+            # For interactive messages, extract selection ID
+            if incoming_message.get("type") == MessageType.INTERACTIVE.value:
+                text = incoming_message.get("text", {})
+                if text.get("interactive_type") == InteractiveType.LIST.value:
+                    selected_account_id = text.get("list_reply", {}).get("id")
+                    if selected_account_id:
+                        # Set the selected account as active
+                        self.state_manager.update_state({
+                            "active_account_id": selected_account_id
+                        })
+                        # Tell headquarters to transition to account dashboard
+                        self.set_result("account_selected")
+                        self.set_awaiting_input(False)
+                        return ValidationResult.success(True)
+
+            # Invalid selection, return failure but stay on component
+            return ValidationResult.failure(
+                message="Invalid selection. Please choose an account from the list.",
+                field="selection",
+                details={"component": self.type}
+            )
+
+        except Exception as e:
+            return ValidationResult.failure(
+                message=str(e),
+                field="display",
+                details={
+                    "component": "multi_account_dashboard",
+                    "error": str(e)
+                }
+            )

--- a/app/core/flow/headquarters.py
+++ b/app/core/flow/headquarters.py
@@ -37,10 +37,17 @@ def get_next_component(
         case ("login", "Greeting"):
             return "login", "LoginApiCall"  # Check if user exists
         case ("login", "LoginApiCall"):
+            if component_result == "send_multi_dashboard":
+                return "multi_account", "MultiAccountDashboard"  # Send multi-account dashboard for tier 5
             if component_result == "send_dashboard":
                 return "account", "AccountDashboard"  # Send account dashboard
             if component_result == "start_onboarding":
                 return "onboard", "Welcome"  # Send first message in onboarding path
+
+        # Multi-account dashboard path
+        case ("multi_account", "MultiAccountDashboard"):
+            if component_result == "account_selected":
+                return "account", "AccountDashboard"  # Transition to selected account's dashboard
 
         # Onboard path
         case ("onboard", "Welcome"):
@@ -68,6 +75,8 @@ def get_next_component(
                 return "view_ledger", "ProcessingNow"  # Send message while API call processes
             if component_result == "upgrade_membertier":
                 return "upgrade_membertier", "ConfirmUpgrade"  # Send upgrade confirmation message
+            if component_result == "switch_account":
+                return "multi_account", "MultiAccountDashboard"  # Switch to multi-account dashboard
 
         # Offer secured credex path
         case ("offer_secured", "AmountInput"):


### PR DESCRIPTION
# Multi-Account Dashboard Implementation

## Overview
This merge implements multi-account dashboard functionality for tier 5 members, allowing them to manage and switch between multiple accounts efficiently.

## Key Changes

### New Components
- Added `MultiAccountDashboard` component for tier 5 users
  - Displays list of owned accounts with balances
  - Handles account selection and switching
  - Shows truncated account handles (24 char limit) for titles
  - Account name and net assets for description

### Modified Components

#### LoginApiCall
- Added tier check in login flow
- Routes tier 5 members to multi-account dashboard
- Other tiers continue to personal account dashboard

#### AccountDashboard
- Added "Switch Account" option for tier 5 members
- Updated member actions section to include account switching
- Added new valid path for account switching

#### Flow Changes
- Updated headquarters.py with new routing logic
  - Added multi-account dashboard path
  - Implemented account selection handling
  - Added switch account functionality

#### Error Handling
- Enhanced processor.py with improved validation error handling
  - Distinguishes between validation and non-validation failures
  - Keeps users on current component for validation errors
  - Maintains login flow transition for other failures

### Component Registration
- Updated __init__.py to expose MultiAccountDashboard
- Added new component to __all__ exports

## Technical Details
- WhatsApp UI constraints handled (24 char limit for titles)
- Interactive menu implementation for account selection
- State management for active account tracking
- Validation and error handling improvements

## Testing Notes
Key flows to test:
1. Tier 5 member login -> Multi-account dashboard
2. Account selection and switching
3. Balance display formatting
4. Error handling for invalid selections (may be incomplete. not material)
5. Validation error messages
